### PR TITLE
Only use regex_macros as a plugin (remove runtime dependency)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // #![deny(warnings)]
 #![deny(bad_style)]
 
-#[plugin]
+#[plugin] #[no_link]
 extern crate regex_macros;
 extern crate regex;
 extern crate hyper;


### PR DESCRIPTION
This avoids the following error:

```
target/hello-rustless: error while loading shared libraries: libregex_macros-bdbdbfedad0748ac.so: cannot open shared object file: No such file or directory
```