### PR TITLE
Migrate rustless from std::old_io to std::io for compatibility with recent releases of Iron

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -86,7 +86,7 @@ fn main() {
             });
 
             // Using after_validation callback to check token
-            admin_ns.after_validation(|&: _client, params| {
+            admin_ns.after_validation(|_client, params| {
 
                 match params.find("token") {
                     // We can unwrap() safely because token in validated already

--- a/src/backend/iron.rs
+++ b/src/backend/iron.rs
@@ -1,5 +1,5 @@
 use url;
-use std::old_io::net::ip;
+use std::net::SocketAddr;
 use plugin::{Extensible, Pluggable};
 pub use iron::{Url, Handler};
 
@@ -42,7 +42,7 @@ impl backend::AsUrl for Url {
 }
 
 impl<'a> backend::Request for iron::Request<'a> {
-    fn remote_addr(&self) -> &ip::SocketAddr { &self.remote_addr }
+    fn remote_addr(&self) -> &SocketAddr { &self.remote_addr }
     fn headers(&self) -> &header::Headers { &self.headers }
     fn method(&self) -> &method::Method { &self.method }
     fn url(&self) -> &backend::AsUrl { &self.url }

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -1,5 +1,6 @@
 use std::fmt;
-use std::old_io::net::ip;
+use std::io::Read;
+use std::net::SocketAddr;
 use url;
 
 use framework::media;
@@ -8,9 +9,9 @@ use server::method;
 use server::header;
 use super::super::errors;
 
-pub trait Body: Reader { }
+pub trait Body: Read { }
 
-impl Body for Box<Reader + 'static> { }
+impl Body for Box<Read + 'static> { }
 
 pub trait AsUrl {
     fn scheme(&self) -> &str;
@@ -24,7 +25,7 @@ pub trait AsUrl {
 }
 
 pub trait Request: fmt::Debug + ::Extensible {
-    fn remote_addr(&self) -> &ip::SocketAddr;
+    fn remote_addr(&self) -> &SocketAddr;
     fn headers(&self) -> &header::Headers;
     fn method(&self) -> &method::Method;
     fn url(&self) -> &AsUrl;

--- a/src/backend/simple_request.rs
+++ b/src/backend/simple_request.rs
@@ -1,10 +1,12 @@
-use std::old_io;
 use std::fmt;
-use std::old_io::net::ip;
+use std::fs::File;
+use std::io;
+use std::net::SocketAddr;
+use std::path::Path;
+
 use typemap;
 
 use {Extensible};
-
 use server::method;
 use server::header;
 use super::request;
@@ -15,10 +17,10 @@ use backend::{Request, Url, AsUrl, WrapUrl};
 pub struct SimpleRequest {
     pub url: Url,
     pub ext: typemap::TypeMap,
-    pub remote_addr: ip::SocketAddr,
+    pub remote_addr: SocketAddr,
     pub headers: header::Headers,
     pub method: method::Method,
-    pub body: Box<Reader + 'static>
+    pub body: Box<io::Read + 'static>
 }
 
 impl<'a> Request for SimpleRequest {
@@ -27,7 +29,7 @@ impl<'a> Request for SimpleRequest {
         return &self.url;
     }
 
-    fn remote_addr(&self) -> &ip::SocketAddr {
+    fn remote_addr(&self) -> &SocketAddr {
         return &self.remote_addr;
     }
 
@@ -48,7 +50,9 @@ impl<'a> Request for SimpleRequest {
     }
 
     fn read_to_end(&mut self) -> Result<Option<String>, Box<errors::Error>> {
-        String::from_utf8(self.body.read_to_end().unwrap())
+        let mut bytes = Vec::new();
+        self.body.read_to_end(&mut bytes).unwrap();
+        String::from_utf8(bytes)
             .map(|body| Some(body))
             .map_err(|err| Box::new(err) as Box<errors::Error>)
     }
@@ -64,7 +68,7 @@ impl SimpleRequest {
             ext: typemap::TypeMap::new(),
             remote_addr: "127.0.0.1:8000".parse().unwrap(),
             headers: header::Headers::new(),
-            body: Box::new(old_io::MemReader::new(vec![]))
+            body: Box::new(io::Cursor::new(vec![]))
         }
     }
 
@@ -76,7 +80,7 @@ impl SimpleRequest {
         srq
     }
 
-    pub fn set_remote_addr(&mut self, addr: ip::SocketAddr) {
+    pub fn set_remote_addr(&mut self, addr: SocketAddr) {
         self.remote_addr = addr;
     }
 
@@ -89,11 +93,11 @@ impl SimpleRequest {
     }
 
     pub fn push_string(&mut self, body: String) {
-        self.body = Box::new(old_io::MemReader::new(body.into_bytes()));
+        self.body = Box::new(io::Cursor::new(body.into_bytes()));
     }
 
-    pub fn push_file(&mut self, path: &Path) -> old_io::IoResult<()> {
-        self.body = Box::new(try!(old_io::File::open(path)));
+    pub fn push_file(&mut self, path: &Path) -> io::Result<()> {
+        self.body = Box::new(try!(File::open(path)));
 
         Ok(())
     }

--- a/src/batteries/swagger.rs
+++ b/src/batteries/swagger.rs
@@ -218,7 +218,7 @@ pub fn enable(app: &mut framework::Application, spec: Spec) {
 #[allow(unused_variables)]
 /// Build the basic Swagger 2.0 object
 pub fn build_spec(app: &framework::Application, spec: Spec) -> json::Json {
-    jsonway::object(|&: json| {
+    jsonway::object(|json| {
         // Required. Specifies the Swagger Specification version being used.
         // It can be used by the Swagger UI and other clients to interpret the API listing.
         // The value MUST be "2.0".
@@ -408,7 +408,7 @@ pub fn create_api(path: &str) -> framework::Api {
         api.namespace(path, |docs| {
             docs.get("", |endpoint| {
                 endpoint.summary("Get Swagger 2.0 specification of this API");
-                endpoint.handle(|&: mut client, _params| {
+                endpoint.handle(|mut client, _params| {
                     client.set_header(header::AccessControlAllowOrigin::AllowStar);
                     let swagger_spec = client.app.ext.get::<SwaggerSpecKey>();
                     if swagger_spec.is_some() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use std::old_io;
+use std::io;
 pub use error::{Error};
 use std::error::Error as StdError;
 use valico;
@@ -79,7 +79,7 @@ impl Body {
 impl_basic_err!(Body, "Body");
 
 #[derive(Debug)]
-pub struct File(pub old_io::IoError);
+pub struct File(pub io::Error);
 impl_basic_err!(File, "File");
 
 #[derive(Debug, Copy)]

--- a/src/framework/client.rs
+++ b/src/framework/client.rs
@@ -1,6 +1,7 @@
 use serialize::json;
 use typemap;
 use std::env;
+use std::path::Path;
 
 use backend;
 use errors::{self, Error};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@
 #![feature(plugin)]
 #![feature(collections)]
 #![feature(core)]
-#![feature(env)]
-#![feature(old_io)]
-#![feature(old_path)]
+#![feature(io)]
+#![feature(net)]
+#![feature(path)]
 // #![deny(warnings)]
 #![deny(bad_style)]
 

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -1,4 +1,3 @@
-use std::str;
 use valico::json_dsl;
 use valico::json_schema;
 use rustless::server::status;

--- a/tests/serializers.rs
+++ b/tests/serializers.rs
@@ -1,5 +1,6 @@
 use serialize::json;
-use std::str::from_utf8;
+use std::io::Read;
+use std::str;
 
 use jsonway;
 
@@ -32,7 +33,9 @@ fn it_serializes_json_properly() {
         assert_eq!(*mime_type, mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, vec![]));
     }
 
-    let body: json::Json = from_utf8(response.read_to_end().unwrap().as_slice()).unwrap().parse().unwrap();
+    let mut bytes = Vec::new();
+    response.read_to_end(&mut bytes).unwrap();
+    let body: json::Json = str::from_utf8(&bytes).unwrap().parse().unwrap();
 
     assert!(body.find("uptime").is_some());
     assert!(body.find("echo_params").is_some());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 // #![deny(warnings)]
 #![deny(bad_style)]
 #![feature(core)]
-#![feature(old_io)]
+#![feature(io)]
 
 #[macro_use]
 extern crate rustless;
@@ -33,7 +33,14 @@ macro_rules! call_app {
 
 #[macro_export]
 macro_rules! resp_body {
-    ($resp:ident) => (str::from_utf8($resp.read_to_end().unwrap().as_slice()).unwrap())
+    ($resp:ident) => {
+        {
+            use std::io::Read;
+            let mut bytes = Vec::new();
+            $resp.read_to_end(&mut bytes).unwrap();
+            String::from_utf8(bytes).unwrap()
+        }
+    }
 }
 
 #[macro_export]

--- a/tests/versioning.rs
+++ b/tests/versioning.rs
@@ -14,7 +14,7 @@ fn it_pass_accept_header_versioning() {
     // not found because accept-header is not present
     assert_eq!(err_resp.response.status, status::StatusCode::NotFound);
 
-    let response = call_app!(app, Get, "http://127.0.0.1:3000/info", |&: rq| {
+    let response = call_app!(app, Get, "http://127.0.0.1:3000/info", |rq| {
         rq.headers_mut().set(
             header::Accept( vec![mime!("application/vnd.infoapi.v1+json")] )
         );
@@ -125,7 +125,7 @@ fn it_pass_nesting_crazy_mixed_versioning_never_do_this() {
         }))
     });
 
-    let response = call_app!(app, Get, "http://127.0.0.1:3000/v2/info?ver=v3", |&: rq| {
+    let response = call_app!(app, Get, "http://127.0.0.1:3000/v2/info?ver=v3", |rq| {
         rq.headers_mut().set(
             header::Accept( vec![mime!("application/vnd.infoapi.v1+json")] )
         );
@@ -133,7 +133,7 @@ fn it_pass_nesting_crazy_mixed_versioning_never_do_this() {
 
     assert_eq!(response.status, status::StatusCode::Ok);
 
-    let err_resp = call_app!(app, Get, "http://127.0.0.1:3000/v2/nested_nested_info", |&: rq| {
+    let err_resp = call_app!(app, Get, "http://127.0.0.1:3000/v2/nested_nested_info", |rq| {
         rq.headers_mut().set(
             header::Accept( vec![mime!("application/vnd.infoapi.v1+json")] )
         );


### PR DESCRIPTION
_Allows rustless to build with recent nightlies and recent versions of its dependencies, namely iron._

#### Changes
* Moves from std::old_io -> std::io
  * old_io::Reader -> io::Read
  * path::Path
  * old_io::File -> fs::File
* Removes obsolete closure syntax
* Removes #![feature(env)], as env is now stable