### PR TITLE
Fix compilation errors with rust 1.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "0.1"
 lazy_static = "0.1"
 rustc-serialize = "0.3"
 valico = "0.8"
-hyper = "0.7"
+hyper = "0.8"
 queryst = "0.1"
 jsonway = "0.3"
 url = "0.5"
@@ -43,7 +43,7 @@ default-features = false
 
 [dependencies.iron]
 optional = true
-version = "0.2"
+version = "0.3"
 
 [dependencies.bodyparser]
 optional = true

--- a/src/backend/response.rs
+++ b/src/backend/response.rs
@@ -11,7 +11,7 @@ pub use iron::response::ResponseBody;
 pub struct Response {
     pub status: status::StatusCode,
     pub headers: header::Headers,
-    pub body: Option<Box<WriteBody + Send>>,
+    pub body: Option<Box<WriteBody>>,
     pub ext: typemap::TypeMap
 }
 
@@ -27,7 +27,7 @@ impl Response {
     }
 
     #[allow(dead_code)]
-    pub fn from(status: status::StatusCode, body: Box<WriteBody + Send>) -> Response {
+    pub fn from(status: status::StatusCode, body: Box<WriteBody>) -> Response {
         Response {
             status: status,
             headers: header::Headers::new(),
@@ -53,7 +53,7 @@ impl Response {
         response
     }
 
-    pub fn replace_body(&mut self, body: Box<WriteBody + Send>) {
+    pub fn replace_body(&mut self, body: Box<WriteBody>) {
         self.body = Some(body)
     }
 }

--- a/src/batteries/swagger.rs
+++ b/src/batteries/swagger.rs
@@ -3,7 +3,7 @@ use valico::json_dsl;
 use std::collections;
 use serialize::json::{self, ToJson};
 use jsonway::{self, MutableJson};
-use framework::{self, Nesting, ApiHandler};
+use framework::{self, Nesting};
 use server::mime;
 use server::header;
 use server::method;

--- a/src/framework/api.rs
+++ b/src/framework/api.rs
@@ -3,9 +3,9 @@ use serialize::json;
 use backend;
 use server::mime;
 use server::header;
-use errors::{self, Error};
-
-use framework::{self, ApiHandler};
+use errors;
+ 
+use framework;
 use framework::nesting::{self, Nesting, Node};
 use framework::media;
 use framework::path;


### PR DESCRIPTION
Bump hyper and iron versions and make some small changes to build cleanly with
the latest version of rust.