### PR TITLE
Updating to use version 0.3 of bodyparser to match iron.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.3"
 
 [dependencies.bodyparser]
 optional = true
-version = "0.0"
+version = "0.3"
 
 [dependencies.plugin]
 optional = true


### PR DESCRIPTION
Rustless does not currently compile due to picking up a different version of bodyparser and iron. In my change I have updated to use a specific version of bodyparser to match iron.