### PR TITLE
disable ssl by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ name = "tests"
 [features]
 default = ["iron_backend"]
 iron_backend = ["iron", "bodyparser", "plugin"]
+ssl = ["hyper/ssl","cookie/secure"]
 
 [dependencies]
 regex = "0.1"
 lazy_static = "0.2"
 valico = "1"
-hyper = "0.9"
 queryst = "1"
 jsonway = "1"
 url = "1"
@@ -37,6 +37,10 @@ typeable = "0.1"
 traitobject = "0.0"
 serde = "0.8"
 serde_json = "0.8"
+
+[dependencies.hyper]
+version = "0.9"
+default-features = false
 
 [dependencies.cookie]
 version = "0.3"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -107,10 +107,15 @@ fn main() {
                 endpoint.handle(|client, _params| {
                     {
                         let cookies = client.request.cookies();
+                        #[cfg(ssl)]
                         let signed_cookies = cookies.signed();
 
                         let user_cookie = Cookie::new("session".to_string(), "verified".to_string());
+
+                        #[cfg(ssl)]
                         signed_cookies.add(user_cookie);
+                        #[cfg(not(ssl))]
+                        cookies.add(user_cookie);
                     }
 
                     client.text("Everything is OK".to_string())


### PR DESCRIPTION
I think most users don't need the ssl feature as default (because using a reverse proxy like nginx is recommended anyway).
So I'd add a `ssl` feature [like iron](https://github.com/iron/iron/blob/master/Cargo.toml#L24).