### PR TITLE
fix(framework) disable default features on hyper issue#80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ iron_backend = ["iron", "bodyparser", "plugin"]
 regex = "0.1"
 lazy_static = "0.2"
 valico = "1"
-hyper = "0.9"
 queryst = "1"
 jsonway = "1"
 url = "1"
@@ -40,6 +39,10 @@ serde_json = "0.8"
 
 [dependencies.cookie]
 version = "0.3"
+default-features = false
+
+[dependencies.hyper]
+version = "0.9"
 default-features = false
 
 [dependencies.iron]


### PR DESCRIPTION
hyper is imported with defaults on and this brings openssl which could not be desirable and could clash with other openssl version.

Have changed Cargo.toml to import hyper with default features false