### PR TITLE
feat(framework): add support for HTTP PATCH

### DIFF
--- a/src/batteries/swagger.rs
+++ b/src/batteries/swagger.rs
@@ -605,7 +605,8 @@ fn build_endpoint_definition(endpoint: &framework::Endpoint, context: &mut WalkC
 
             match endpoint.method {
                 method::Method::Post |
-                method::Method::Put => {
+                method::Method::Put |
+                method::Method::Patch => {
                     for param in final_params.iter_mut() {
                         match param.place {
                             Place::Query => param.place = Place::FormData,

--- a/src/framework/nesting.rs
+++ b/src/framework/nesting.rs
@@ -108,6 +108,10 @@ pub trait Nesting: Node {
     -> endpoint::EndpointHandlerPresent {
         self.mount(endpoint::Endpoint::build(method::Method::Head, path, builder));
     }
+    fn patch<F>(&mut self, path: &str, builder: F) where F: FnOnce(&mut endpoint::Endpoint)
+    -> endpoint::EndpointHandlerPresent {
+        self.mount(endpoint::Endpoint::build(method::Method::Patch, path, builder));
+    }
 
     fn before<F: 'static>(&mut self, callback: F) where F: for<'a> Fn(&'a mut client::Client, &JsonValue)
     -> backend::HandleSuccessResult + Send+Sync {


### PR DESCRIPTION
This PR simply adds a `patch` method to `Nesting`, to allow utilizing the PATCH method as defined in [RFC 5789](https://tools.ietf.org/html/rfc5789).